### PR TITLE
Added Data History & Field Comment Log/Data Resolution Workflow icons

### DIFF
--- a/Shazam.php
+++ b/Shazam.php
@@ -207,12 +207,13 @@ class Shazam extends \ExternalModules\AbstractExternalModule
                 }
             }
             // self::log($shazamParams, $shazamParams);
-
+            
             ?>
                 <script type='text/javascript' src="<?php print $this->getUrl("js/shazam.js", true, true) ?>"></script>
                 <script type='text/javascript'>
                     $(document).ready(function () {
                         Shazam.params = <?php print json_encode($shazamParams); ?>;
+                        Shazam.displayIcons = <?php print json_encode($this->getProjectSetting("shazam-display-icons", $project_id)); ?>;
                         //Shazam.log("Shazam Params", Shazam.params);
                         Shazam.Transform();
                     });

--- a/config.json
+++ b/config.json
@@ -57,6 +57,11 @@
       "key": "shazam-descriptive",
       "name": "This module is configured by a link on the sidebar called 'Shazam Setup'.<br><i>The acutal config is stored in a hidden shazam-config external module variable.</i>",
       "type": "descriptive"
+    },
+    {
+      "key": "shazam-display-icons",
+      "name": "Display Data History & Field Comment Log/Data Resolution Workflow Icons",
+      "type": "checkbox"
     }
   ]
 }

--- a/js/shazam.js
+++ b/js/shazam.js
@@ -177,6 +177,14 @@ Shazam.Transform = function() {
 
                     $(this).html(source_data.children());
 
+                    // Add Data History & Field Comment Log/Data Resolution Workflow icons
+                    if ($(this).find(".rc-autocomplete").length === 0 && $(this).find(".note").length === 0 && $(this).find("div").length === 0) {
+                        $(this).append('<br>');
+                    }
+                    if (source_tr.find("a").length !== 0) {
+                        $(this).append(source_tr.find("a").parent().html().replace('<br>', ''));
+                    }
+
                     // Hide the source TRs. (two methods here)
                     //$(real_tr).css('display','none');
                     $(source_tr).css('position', 'absolute').css('left', '-1000px');

--- a/js/shazam.js
+++ b/js/shazam.js
@@ -178,11 +178,13 @@ Shazam.Transform = function() {
                     $(this).html(source_data.children());
 
                     // Add Data History & Field Comment Log/Data Resolution Workflow icons
-                    if ($(this).find(".rc-autocomplete").length === 0 && $(this).find(".note").length === 0 && $(this).find("div").length === 0) {
-                        $(this).append('<br>');
-                    }
-                    if (source_tr.find("a").length !== 0) {
-                        $(this).append(source_tr.find("a").parent().html().replace('<br>', ''));
+                    if (Shazam.displayIcons === true) {
+                        if ($(this).find(".rc-autocomplete").length === 0 && $(this).find(".note").length === 0 && $(this).find("div").length === 0) {
+                            $(this).append('<br>');
+                        }
+                        if (source_tr.find("a").length !== 0) {
+                            $(this).append(source_tr.find("a").parent().html().replace('<br>', ''));
+                        }
                     }
 
                     // Hide the source TRs. (two methods here)


### PR DESCRIPTION
The option to display Data History & Field Comment Log/Data Resolution Workflow icons in Shazam tables has been added. Per-project configuration has been added (variable _shazam-display-icons_).