### PR TITLE
Fix for displaying label of descriptive text fields in shazam layouts

### DIFF
--- a/js/shazam.js
+++ b/js/shazam.js
@@ -166,10 +166,10 @@ Shazam.Transform = function() {
                         source_label = source_tr.find('td').not('questionnum').find('label').html().trim();
                     } else if ($('table[role="presentation"]', source_tr).find('td:first-child').length > 0) {
                         source_label = $('table[role="presentation"]', source_tr).find('td:first-child').html().trim();
-                    } else if (align === "left" && source_tr.find('td').children().length === 0) {
+                    } else if (align === "left" && source_tr.children('td').length === 1) { // descriptive text field trs have exactly one immediate child td (which may contain other tables with tds)
                         Shazam.log('Label2');
                         // Could be a descriptive field, so lets just take the content
-                        source_label = source_tr.find('td').html();
+                        source_label = source_tr.find('td:first-child').html().trim();
                     } else if ($('.sldrparent', source_tr).length > 0) {
                         Shazam.log('Label3');
                         // Is a slider


### PR DESCRIPTION
Using <span class="shazam">desc_text_field_name:label</span> should bring in the contents of the descriptive text field's label (e.g. to facilitate piping form data into shazam layouts). I found this is not working in release 1.1.5.

Descriptive text field trs have exactly one immediate child td (which may contain other tables
with tds), so this fix checks this condition and reads the whole html contents of the row's first td. It seems like the affected ``if`` block is specifically for descriptive text fields (i.e. and nothing else).