### PR TITLE
Inlining of JS code / Setting for console logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode/

--- a/Shazam.php
+++ b/Shazam.php
@@ -345,14 +345,23 @@ class Shazam extends \ExternalModules\AbstractExternalModule
 			// //$js_url = $this->getUrl("js/shazam.js", true, true);
 
             $skipApi = $this->getProjectSetting("do-not-use-api-endpoint");
+            $inline = $this->getProjectSetting("shazam-inline-js");
             if ($skipApi) {
                 $jsUrl = $this->getUrl("js/shazam.js");
             } else {
                 $jsUrl = $this->getUrl('js/shazam.js', false, true);
             }
 
+            // Inject JavaScript.
+            if ($inline) {
+                $jsText = file_get_contents(__DIR__ . "/js/shazam.js");
+                echo "<script type=\"text/javascript\">\n$jsText\n</script>";
+            }
+            else {
+                echo "<script type=\"text/javascript\" src=\"$jsUrl\"></script>";
+            }
+
             ?>
-                <script type='text/javascript' src="<?php echo $jsUrl ?>"></script>
                 <script type='text/javascript'>
                     if (typeof Shazam === "undefined") {
                         // There has been an error loading the js file.

--- a/Shazam.php
+++ b/Shazam.php
@@ -244,6 +244,7 @@ class Shazam extends \ExternalModules\AbstractExternalModule
             $this->emDebug("PAGE: " . PAGE);
             $this->emDebug("INSTRUMENT: ". $instrument);
             $jsUrl = $this->getUrl("js/shazam.js");
+            $consoleLog = $this->getProjectSetting("enable-project-console-logging");
 
             // Highlight shazam fields on the page
             ?>
@@ -258,7 +259,7 @@ class Shazam extends \ExternalModules\AbstractExternalModule
                     );
                 } else {
                     Shazam.fields = <?php echo json_encode($this->shazam_instruments[$instrument]); ?>;
-                    Shazam.isDev = <?php echo self::isDev(); ?>;
+                    Shazam.isDev = <?php echo $consoleLog ? 1 : 0; ?>;
                     $(document).ready(function () {
                         Shazam.highlightFields();
                     });
@@ -346,6 +347,7 @@ class Shazam extends \ExternalModules\AbstractExternalModule
 
             $skipApi = $this->getProjectSetting("do-not-use-api-endpoint");
             $inline = $this->getProjectSetting("shazam-inline-js");
+            $consoleLog = $this->getProjectSetting("enable-project-console-logging");
             if ($skipApi) {
                 $jsUrl = $this->getUrl("js/shazam.js");
             } else {
@@ -373,7 +375,7 @@ class Shazam extends \ExternalModules\AbstractExternalModule
                     } else {
                         $(document).ready(function () {
                             Shazam.params       = <?php print json_encode($shazamParams); ?>;
-                            Shazam.isDev        = <?php echo self::isDev(); ?>;
+                            Shazam.isDev        = <?php echo $consoleLog ? 1 : 0; ?>;
                             Shazam.displayIcons = <?php print json_encode($this->getProjectSetting("shazam-display-icons")); ?>;
                             Shazam.isSurvey     = <?php print json_encode($isSurvey); ?>;
                             Shazam.Transform();

--- a/config.json
+++ b/config.json
@@ -87,8 +87,13 @@
     },
     {
       "key": "enable-project-debug-logging",
-      "name": "<b>Enable Debug Logging</b><br>If you have the Stanford emLogger external module installed and configured, you can enable additional debug-level logging for this project",
+      "name": "<b>Enable Stanford emLogger Logging</b><br>If you have the Stanford emLogger external module installed and configured, you can enable additional debug-level logging for this project",
       "required": false,
+      "type": "checkbox"
+    },
+    {
+      "key": "enable-project-console-logging",
+      "name": "<b>Enable Console Debug Logging</b><br>You can enable debug-level logging to the browser console for this project",
       "type": "checkbox"
     },
     {

--- a/config.json
+++ b/config.json
@@ -90,6 +90,11 @@
       "name": "<b>Enable Debug Logging</b><br>If you have the Stanford emLogger external module installed and configured, you can enable additional debug-level logging for this project",
       "required": false,
       "type": "checkbox"
+    },
+    {
+      "key": "shazam-inline-js",
+      "name": "Deliver JavaScript <b>inline</b><br>Use this setting when your API-endpoint is not open to the Internet",
+      "type": "checkbox"
     }
   ],
   "compatibility": {


### PR DESCRIPTION
Two small enhancements for your consideration:

- Inlining of shazam.js: A new project setting that allows inlining of JS. This is useful when only the survey (and static resource) endpoints are exposed to the Internet.
- New project-level setting to control console logging (instead of by the isDev function).

Cheers!