### PR TITLE
Fix shazam issue if field embedding was used at the same time

### DIFF
--- a/Shazam.php
+++ b/Shazam.php
@@ -528,7 +528,7 @@ class Shazam extends \ExternalModules\AbstractExternalModule
                             Shazam.isDev        = <?php echo $consoleLog ? 1 : 0; ?>;
                             Shazam.displayIcons = <?php print json_encode($this->getProjectSetting("shazam-display-icons")); ?>;
                             Shazam.isSurvey     = <?php print json_encode($isSurvey); ?>;
-                            Shazam.Transform();
+                            setTimeout(function(){ Shazam.Transform(); }, 1);
                         });
                     }
                 </script>


### PR DESCRIPTION
The page was still loading and all element was "invisible" in shazam because the height/width was still 0 due to field embedding was being called.

A timeout of 1 ms fix the issue.

https://community.projectredcap.org/questions/99679/redcap-106-shazam-tables-mirror-visibility-branchi.html?childToView=99707#answer-99707