### PR TITLE
Update Shazam.php

### DIFF
--- a/Shazam.php
+++ b/Shazam.php
@@ -298,7 +298,7 @@ class Shazam extends \ExternalModules\AbstractExternalModule
         $this->emDebug("Sorted Keys Before", array_keys($backup_configs));
 
         // Only keep so many copies of backups
-        $this->backup_con7figs = array_slice($backup_configs,0,self::BACKUP_COPIES,true);
+        $this->backup_configs = array_slice($backup_configs,0,self::BACKUP_COPIES,true);
 
         $this->emDebug("Sorted Keys After", array_keys($this->backup_configs));
 


### PR DESCRIPTION
I noticed a typo in shazam.php when saving the backup configs. `$this->backup_con7figs` looks like it should be `$this->backup_configs`. Once I made this change I was able to see restore points under the "Recover Previously Saved Version" dropdown. I created a new branch (fbb-shazam-fix) with the fix. 